### PR TITLE
Report syncers

### DIFF
--- a/report-syncers.sh
+++ b/report-syncers.sh
@@ -125,6 +125,7 @@ while read INSTANCE; do
 	RAWSYNC=`curl -n "$INSTANCE"`
 	if [ $? -ne 0 ]; then # Download failed, the report won't be complete
 		((INCOMPLETE++))
+		continue
 	fi
 
 	# Put all output in one line and then break into lines per entry

--- a/report-syncers.sh
+++ b/report-syncers.sh
@@ -127,6 +127,11 @@ while read INSTANCE; do
 		((INCOMPLETE++))
 		continue
 	fi
+	echo "${RAWSYNC}" | grep '<title type="text">Synchronizers</title>' >/dev/null
+	if [ $? -ne 0 ]; then # Result does not contain Synchronizers, it's an error
+		((INCOMPLETE++))
+		continue
+	fi
 
 	# Put all output in one line and then break into lines per entry
 	echo "${RAWSYNC}" | sed 's/\r//g' | sed 's/<\/entry>/<\/entry>\n/g' | grep "ServiceUrl" | while read line; do


### PR DESCRIPTION
Check downloaded XML for contents. Sometime there is no error code but the output is in fact erroneous.